### PR TITLE
Fix deployment bug

### DIFF
--- a/openwhisk/openwhisk.js
+++ b/openwhisk/openwhisk.js
@@ -183,7 +183,7 @@ module.exports = function(RED) {
           })
 
           var action = { 
-            exec: { kind: 'nodejs', code: n.func },
+            exec: { kind: 'nodejs:6', code: n.func },
             parameters: params
           };
 


### PR DESCRIPTION
I found a bug which a lot of users encountered. Could you check and solve it on Bluemix?

![23163651_1261060390664592_1806985919_n](https://user-images.githubusercontent.com/6851138/32668652-8892fb08-c681-11e7-88b1-9c116723394c.jpg)

[Details]
When I deploy OpenWhisk node with modified code on Node-RED, debug tab showed an error, "The 'nodejs' runtime is no longer supported.". I think that OpenWhisk node should use "nodejs:6" instead of "nodejs" as language option because specifications of Cloud Functions were changed.